### PR TITLE
#3: Press on ‘Patient ID Number’ field —> enter at the end character —> enter character ‘a’ —> Click “Back” button on keyboard —> The app should work well.

### DIFF
--- a/iBOCA/Demographics.swift
+++ b/iBOCA/Demographics.swift
@@ -178,6 +178,7 @@ class Demographics: ViewController, MFMailComposeViewControllerDelegate, UITextF
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        MRField.delegate = self
         AgePicker.delegate = self
         GenderPicker.delegate = self
         EthnicityPicker.delegate = self


### PR DESCRIPTION
Update: Add delegate to Patient ID Number textfield
