### PR TITLE
Issue may 23 2019

### DIFF
--- a/iBOCA/Base.lproj/Main.storyboard
+++ b/iBOCA/Base.lproj/Main.storyboard
@@ -2266,18 +2266,16 @@
                         <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EMZ-3Z-SVK">
-                                <rect key="frame" x="871" y="46" width="87" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EMZ-3Z-SVK">
+                                <rect key="frame" x="20" y="30" width="65" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 <state key="normal" title="Back"/>
                                 <connections>
                                     <segue destination="BYZ-38-t0r" kind="show" id="e4f-h0-eqr"/>
                                 </connections>
                             </button>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" pagingEnabled="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="axn-CN-i5a">
-                                <rect key="frame" x="20" y="84" width="984" height="684"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" pagingEnabled="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="axn-CN-i5a">
+                                <rect key="frame" x="20" y="78" width="984" height="640"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <connections>
                                     <outlet property="dataSource" destination="mFE-dR-SxI" id="CqB-8c-hDK"/>
@@ -2286,6 +2284,14 @@
                             </tableView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="EMZ-3Z-SVK" firstAttribute="leading" secondItem="wTL-Pe-RDR" secondAttribute="leadingMargin" id="7wb-ur-xnT"/>
+                            <constraint firstItem="axn-CN-i5a" firstAttribute="leading" secondItem="wTL-Pe-RDR" secondAttribute="leadingMargin" id="M16-3d-Qml"/>
+                            <constraint firstAttribute="bottomMargin" secondItem="axn-CN-i5a" secondAttribute="bottom" id="O9a-iV-gtj"/>
+                            <constraint firstItem="axn-CN-i5a" firstAttribute="trailing" secondItem="wTL-Pe-RDR" secondAttribute="trailingMargin" id="R2L-2L-w7I"/>
+                            <constraint firstItem="axn-CN-i5a" firstAttribute="top" secondItem="EMZ-3Z-SVK" secondAttribute="bottom" id="XHa-ga-8xT"/>
+                            <constraint firstItem="EMZ-3Z-SVK" firstAttribute="top" secondItem="tIi-Em-59u" secondAttribute="bottom" constant="10" id="gx5-Qo-yg8"/>
+                        </constraints>
                     </view>
                     <connections>
                         <outlet property="tableView" destination="axn-CN-i5a" id="V0B-Oh-Xva"/>
@@ -4357,8 +4363,8 @@
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="Ges-mF-PUS"/>
-        <segue reference="kTw-7t-VZN"/>
+        <segue reference="eep-iX-tUz"/>
         <segue reference="fV2-tM-D7d"/>
-        <segue reference="Bhp-ON-e9m"/>
+        <segue reference="e4f-h0-eqr"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/iBOCA/Base.lproj/Main.storyboard
+++ b/iBOCA/Base.lproj/Main.storyboard
@@ -846,9 +846,8 @@
                                     <segue destination="X0q-rm-Xxt" kind="show" id="tL4-Xu-c4y"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bV2-Na-iag">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bV2-Na-iag">
                                 <rect key="frame" x="657" y="110" width="246" height="48"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
                                 <state key="normal" title="Done with Patient"/>
                                 <connections>
@@ -956,9 +955,8 @@
                                     <userDefinedRuntimeAttribute type="boolean" keyPath="translatesAutoresizingMaskIntoConstraints" value="NO"/>
                                 </userDefinedRuntimeAttributes>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oPu-WI-pd0">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oPu-WI-pd0">
                                 <rect key="frame" x="209" y="110" width="105" height="48"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
                                 <state key="normal" title="Results"/>
                                 <connections>
@@ -1001,9 +999,8 @@
                                     <segue destination="oxe-aZ-ydg" kind="show" identifier="SerialSeven" id="G9E-xp-Whb"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Patiant ID" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fZ6-Ae-DEs">
-                                <rect key="frame" x="386" y="129" width="252" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Patiant ID" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fZ6-Ae-DEs">
+                                <rect key="frame" x="475.5" y="137" width="73.5" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -1032,9 +1029,12 @@
                                     <segue destination="Cj1-oS-yny" kind="show" id="ycE-uf-lWw"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="iBoca" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FhK-uw-Mtv">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="iBoca" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FhK-uw-Mtv">
                                 <rect key="frame" x="414" y="37" width="196" height="100"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="100" id="8fc-jI-14M"/>
+                                    <constraint firstAttribute="width" constant="196" id="TyX-zq-hj2"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="58"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -1063,9 +1063,17 @@
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="LE9-Nm-3Tw" firstAttribute="leading" secondItem="9Yk-2H-hs0" secondAttribute="trailing" constant="50" id="Bnj-eA-nmJ"/>
+                            <constraint firstItem="bV2-Na-iag" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="90" id="D3W-Ws-K2z"/>
                             <constraint firstItem="LE9-Nm-3Tw" firstAttribute="centerY" secondItem="9Yk-2H-hs0" secondAttribute="centerY" id="Pph-qt-LfS"/>
+                            <constraint firstItem="bV2-Na-iag" firstAttribute="leading" secondItem="FhK-uw-Mtv" secondAttribute="trailing" constant="47" id="Tdi-VP-fEq"/>
+                            <constraint firstItem="FhK-uw-Mtv" firstAttribute="leading" secondItem="oPu-WI-pd0" secondAttribute="trailing" constant="100" id="W0n-Jb-Tph"/>
+                            <constraint firstItem="FhK-uw-Mtv" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="17" id="bsA-1u-sXM"/>
+                            <constraint firstItem="FhK-uw-Mtv" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="h6j-ZY-N3M"/>
                             <constraint firstItem="4Wv-7u-b6J" firstAttribute="leading" secondItem="2DB-z8-IDB" secondAttribute="trailing" constant="35" id="iio-Zm-zLb"/>
+                            <constraint firstItem="fZ6-Ae-DEs" firstAttribute="top" secondItem="FhK-uw-Mtv" secondAttribute="bottom" id="pgN-zO-to2"/>
                             <constraint firstItem="4Wv-7u-b6J" firstAttribute="centerY" secondItem="2DB-z8-IDB" secondAttribute="centerY" id="sEB-2R-Xhb"/>
+                            <constraint firstItem="fZ6-Ae-DEs" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="sfO-Je-Zz4"/>
+                            <constraint firstItem="oPu-WI-pd0" firstAttribute="top" secondItem="bV2-Na-iag" secondAttribute="top" id="viT-sV-TQp"/>
                         </constraints>
                     </view>
                     <toolbarItems/>
@@ -1110,51 +1118,58 @@
                         <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yMe-5d-oVG">
-                                <rect key="frame" x="55" y="64" width="83" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
-                                <state key="normal" title="Start"/>
-                                <connections>
-                                    <action selector="StartTest:" destination="AyY-Bg-shg" eventType="touchUpInside" id="l1m-cf-CUU"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="l2k-BQ-PqR">
-                                <rect key="frame" x="209" y="64" width="77" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="l2k-BQ-PqR">
+                                <rect key="frame" x="185" y="55" width="51" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 <state key="normal" title="End"/>
                                 <connections>
                                     <action selector="EndTest:" destination="AyY-Bg-shg" eventType="touchUpInside" id="4Tz-Y9-jwK"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PcM-Lg-c2x">
-                                <rect key="frame" x="870" y="55" width="96" height="48"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PcM-Lg-c2x">
+                                <rect key="frame" x="20" y="55" width="65" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 <state key="normal" title="Back"/>
                                 <connections>
                                     <segue destination="BYZ-38-t0r" kind="show" id="LIO-jb-9kR"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ezT-cu-DBi">
-                                <rect key="frame" x="452" y="62" width="431" height="34"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ezT-cu-DBi">
+                                <rect key="frame" x="390" y="67" width="48" height="24"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rxJ-PD-Ge4">
-                                <rect key="frame" x="345" y="65" width="94" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rxJ-PD-Ge4">
+                                <rect key="frame" x="276" y="55" width="74" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 <state key="normal" title="Reset"/>
                                 <connections>
                                     <action selector="Reset:" destination="AyY-Bg-shg" eventType="touchUpInside" id="BIM-wq-V73"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yMe-5d-oVG">
+                                <rect key="frame" x="942" y="55" width="62" height="48"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                <state key="normal" title="Start"/>
+                                <connections>
+                                    <action selector="StartTest:" destination="AyY-Bg-shg" eventType="touchUpInside" id="l1m-cf-CUU"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="PcM-Lg-c2x" firstAttribute="top" secondItem="8dr-IZ-rkK" secondAttribute="bottom" constant="35" id="325-Tq-Gfm"/>
+                            <constraint firstItem="ezT-cu-DBi" firstAttribute="leading" secondItem="rxJ-PD-Ge4" secondAttribute="trailing" constant="40" id="81K-H4-2JX"/>
+                            <constraint firstItem="ezT-cu-DBi" firstAttribute="centerY" secondItem="PcM-Lg-c2x" secondAttribute="centerY" id="A4m-Z4-ZD7"/>
+                            <constraint firstItem="rxJ-PD-Ge4" firstAttribute="leading" secondItem="l2k-BQ-PqR" secondAttribute="trailing" constant="40" id="GdW-UI-4o1"/>
+                            <constraint firstItem="l2k-BQ-PqR" firstAttribute="firstBaseline" secondItem="PcM-Lg-c2x" secondAttribute="firstBaseline" id="INl-ay-8gr"/>
+                            <constraint firstItem="rxJ-PD-Ge4" firstAttribute="firstBaseline" secondItem="PcM-Lg-c2x" secondAttribute="firstBaseline" id="L7T-aJ-TUo"/>
+                            <constraint firstItem="PcM-Lg-c2x" firstAttribute="leading" secondItem="VBe-xp-xjY" secondAttribute="leadingMargin" id="Yie-B5-l4I"/>
+                            <constraint firstItem="yMe-5d-oVG" firstAttribute="firstBaseline" secondItem="PcM-Lg-c2x" secondAttribute="firstBaseline" id="cW4-8K-yfs"/>
+                            <constraint firstItem="l2k-BQ-PqR" firstAttribute="leading" secondItem="PcM-Lg-c2x" secondAttribute="trailing" constant="100" id="mzh-eN-pHK"/>
+                            <constraint firstItem="yMe-5d-oVG" firstAttribute="trailing" secondItem="VBe-xp-xjY" secondAttribute="trailingMargin" id="orb-Wa-Euh"/>
+                        </constraints>
                     </view>
                     <connections>
                         <outlet property="backButton" destination="PcM-Lg-c2x" id="Tzu-Vp-Edt"/>
@@ -1187,18 +1202,8 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oc7-I2-y1A">
-                                <rect key="frame" x="901" y="84" width="79" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
-                                <state key="normal" title="Back"/>
-                                <connections>
-                                    <segue destination="BYZ-38-t0r" kind="show" id="Bhp-ON-e9m"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WYa-6c-l75">
-                                <rect key="frame" x="30" y="84" width="85" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WYa-6c-l75">
+                                <rect key="frame" x="942" y="75" width="62" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 <state key="normal" title="Start"/>
                                 <connections>
@@ -1257,8 +1262,22 @@
                                     <action selector="correctButton:" destination="X0q-rm-Xxt" eventType="touchUpInside" id="Q8v-0w-eGb"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oc7-I2-y1A">
+                                <rect key="frame" x="20" y="75" width="65" height="48"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                <state key="normal" title="Back"/>
+                                <connections>
+                                    <segue destination="BYZ-38-t0r" kind="show" id="Bhp-ON-e9m"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="WYa-6c-l75" firstAttribute="trailing" secondItem="goU-XL-TJq" secondAttribute="trailingMargin" id="SKp-eX-qGd"/>
+                            <constraint firstItem="oc7-I2-y1A" firstAttribute="top" secondItem="Duy-pN-u0O" secondAttribute="bottom" constant="55" id="YCR-TN-fiZ"/>
+                            <constraint firstItem="oc7-I2-y1A" firstAttribute="leading" secondItem="goU-XL-TJq" secondAttribute="leadingMargin" id="ezw-9n-8Ll"/>
+                            <constraint firstItem="WYa-6c-l75" firstAttribute="firstBaseline" secondItem="oc7-I2-y1A" secondAttribute="firstBaseline" id="iPs-Tn-Cpn"/>
+                        </constraints>
                     </view>
                     <connections>
                         <outlet property="back" destination="oc7-I2-y1A" id="Q0b-Ax-cGb"/>
@@ -4337,6 +4356,6 @@
         <segue reference="Ges-mF-PUS"/>
         <segue reference="Ahl-wP-pho"/>
         <segue reference="fV2-tM-D7d"/>
-        <segue reference="OeE-YP-4JC"/>
+        <segue reference="Bhp-ON-e9m"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/iBOCA/Base.lproj/Main.storyboard
+++ b/iBOCA/Base.lproj/Main.storyboard
@@ -360,28 +360,16 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kOo-OD-hLe">
-                                <rect key="frame" x="902" y="67" width="92" height="46"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
-                                <state key="normal" title="Back"/>
-                                <connections>
-                                    <action selector="btnBackTapped:" destination="Soq-Lw-miz" eventType="touchUpInside" id="6FU-gk-pzO"/>
-                                    <segue destination="BYZ-38-t0r" kind="show" id="ZXe-jH-G6o"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ORv-Rw-hsI">
-                                <rect key="frame" x="56" y="71" width="150" height="37"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ORv-Rw-hsI">
+                                <rect key="frame" x="942" y="67" width="62" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 <state key="normal" title="Start"/>
                                 <connections>
                                     <action selector="startButton:" destination="Soq-Lw-miz" eventType="touchUpInside" id="kaa-2A-P9a"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oCK-4i-97i">
-                                <rect key="frame" x="156" y="71" width="105" height="42"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oCK-4i-97i">
+                                <rect key="frame" x="125" y="57.5" width="85" height="60"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="40"/>
                                 <state key="normal" title="Next"/>
                             </button>
@@ -471,16 +459,31 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kOo-OD-hLe">
+                                <rect key="frame" x="20" y="67" width="65" height="48"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                <state key="normal" title="Back"/>
+                                <connections>
+                                    <action selector="btnBackTapped:" destination="Soq-Lw-miz" eventType="touchUpInside" id="6FU-gk-pzO"/>
+                                    <segue destination="BYZ-38-t0r" kind="show" id="ZXe-jH-G6o"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
+                            <constraint firstItem="oCK-4i-97i" firstAttribute="firstBaseline" secondItem="kOo-OD-hLe" secondAttribute="firstBaseline" id="2Mj-vn-pW3"/>
+                            <constraint firstItem="ORv-Rw-hsI" firstAttribute="trailing" secondItem="jqK-8W-CYm" secondAttribute="trailingMargin" id="4FE-Ut-Rt8"/>
                             <constraint firstItem="qdW-PQ-8fm" firstAttribute="centerY" secondItem="xvT-UQ-mje" secondAttribute="centerY" id="6T8-oF-m6Q"/>
+                            <constraint firstItem="kOo-OD-hLe" firstAttribute="top" secondItem="KZy-Si-ySZ" secondAttribute="bottom" constant="47" id="7Vz-Tl-isZ"/>
                             <constraint firstItem="xvT-UQ-mje" firstAttribute="centerY" secondItem="jqK-8W-CYm" secondAttribute="centerY" id="8z3-5T-sug"/>
                             <constraint firstItem="xvT-UQ-mje" firstAttribute="leading" secondItem="jqK-8W-CYm" secondAttribute="leading" constant="56" id="C5I-FH-AbH"/>
+                            <constraint firstItem="ORv-Rw-hsI" firstAttribute="firstBaseline" secondItem="kOo-OD-hLe" secondAttribute="firstBaseline" id="Ii1-Sj-8JZ"/>
                             <constraint firstItem="Y07-Xe-95y" firstAttribute="leading" secondItem="jqK-8W-CYm" secondAttribute="leading" constant="56" id="afZ-lI-KTj"/>
+                            <constraint firstItem="kOo-OD-hLe" firstAttribute="leading" secondItem="jqK-8W-CYm" secondAttribute="leadingMargin" id="co0-zi-wLE"/>
                             <constraint firstItem="Y07-Xe-95y" firstAttribute="top" secondItem="KZy-Si-ySZ" secondAttribute="bottom" constant="159" id="hTI-z4-4e4"/>
                             <constraint firstAttribute="trailing" secondItem="qdW-PQ-8fm" secondAttribute="trailing" constant="56" id="muH-ZN-3UT"/>
                             <constraint firstAttribute="trailing" secondItem="Y07-Xe-95y" secondAttribute="trailing" constant="56" id="qTy-JX-IpB"/>
+                            <constraint firstItem="oCK-4i-97i" firstAttribute="leading" secondItem="kOo-OD-hLe" secondAttribute="trailing" constant="40" id="s3X-Z9-QfK"/>
                             <constraint firstItem="QDC-WX-DA2" firstAttribute="top" secondItem="Y07-Xe-95y" secondAttribute="bottom" id="tXC-oe-hto"/>
                         </constraints>
                     </view>
@@ -4323,9 +4326,10 @@
         <image name="seth1.jpg" width="960" height="960"/>
     </resources>
     <inferredMetricsTieBreakers>
+        <segue reference="KbP-HI-14n"/>
         <segue reference="Ges-mF-PUS"/>
-        <segue reference="eep-iX-tUz"/>
+        <segue reference="Ahl-wP-pho"/>
         <segue reference="fV2-tM-D7d"/>
-        <segue reference="HD1-tR-rkD"/>
+        <segue reference="OeE-YP-4JC"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/iBOCA/Base.lproj/Main.storyboard
+++ b/iBOCA/Base.lproj/Main.storyboard
@@ -1364,9 +1364,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ebm-5t-8nE">
-                                <rect key="frame" x="828" y="20" width="127" height="88"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ebm-5t-8nE">
+                                <rect key="frame" x="20" y="20" width="67" height="49"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="31"/>
                                 <state key="normal" title="Back"/>
                                 <connections>
@@ -1435,6 +1434,10 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <accessibility key="accessibilityConfiguration" label="Credits"/>
+                        <constraints>
+                            <constraint firstItem="Ebm-5t-8nE" firstAttribute="top" secondItem="2P3-Em-S2j" secondAttribute="bottom" id="55u-rV-xaV"/>
+                            <constraint firstItem="Ebm-5t-8nE" firstAttribute="leading" secondItem="gOA-OW-sks" secondAttribute="leadingMargin" id="5dF-Cl-ZJv"/>
+                        </constraints>
                     </view>
                     <connections>
                         <outlet property="versionLabel" destination="6E6-ae-4Db" id="ob4-xw-qup"/>
@@ -4354,7 +4357,7 @@
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="Ges-mF-PUS"/>
-        <segue reference="Ahl-wP-pho"/>
+        <segue reference="kTw-7t-VZN"/>
         <segue reference="fV2-tM-D7d"/>
         <segue reference="Bhp-ON-e9m"/>
     </inferredMetricsTieBreakers>

--- a/iBOCA/Base.lproj/Main.storyboard
+++ b/iBOCA/Base.lproj/Main.storyboard
@@ -536,9 +536,8 @@
                                     <action selector="EndTest:" destination="kzf-ng-R8q" eventType="touchUpInside" id="Quw-UY-7cV"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JFY-6y-BWw">
-                                <rect key="frame" x="871" y="66" width="133" height="50"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JFY-6y-BWw">
+                                <rect key="frame" x="20" y="67" width="65" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 <state key="normal" title="Back"/>
                                 <connections>
@@ -567,9 +566,8 @@
                                     <action selector="sequenceSelected:" destination="kzf-ng-R8q" eventType="touchUpInside" id="6Of-yo-uyl"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hjr-fl-gq9">
-                                <rect key="frame" x="46" y="66" width="87" height="50"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hjr-fl-gq9">
+                                <rect key="frame" x="942" y="67" width="62" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 <state key="normal" title="Start"/>
                                 <connections>
@@ -578,6 +576,12 @@
                             </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="Hjr-fl-gq9" firstAttribute="trailing" secondItem="55V-EG-XhK" secondAttribute="trailingMargin" id="6Cb-s5-9uU"/>
+                            <constraint firstItem="JFY-6y-BWw" firstAttribute="top" secondItem="8ax-ma-9lx" secondAttribute="bottom" constant="47" id="HV7-OX-jWm"/>
+                            <constraint firstItem="JFY-6y-BWw" firstAttribute="leading" secondItem="55V-EG-XhK" secondAttribute="leadingMargin" id="WP1-rZ-gOz"/>
+                            <constraint firstItem="Hjr-fl-gq9" firstAttribute="firstBaseline" secondItem="JFY-6y-BWw" secondAttribute="firstBaseline" id="vaG-Bf-iNL"/>
+                        </constraints>
                     </view>
                     <connections>
                         <outlet property="backButton" destination="JFY-6y-BWw" id="pHx-IS-Lkm"/>
@@ -605,27 +609,16 @@
                         <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bZv-R1-K4j">
-                                <rect key="frame" x="42" y="64" width="90" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
-                                <state key="normal" title="Start"/>
-                                <connections>
-                                    <action selector="StartTest:" destination="uCe-Dr-4Kv" eventType="touchUpInside" id="5xX-ga-a5D"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yCR-2Z-sau">
-                                <rect key="frame" x="193" y="64" width="66" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yCR-2Z-sau">
+                                <rect key="frame" x="193" y="64" width="51" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 <state key="normal" title="End"/>
                                 <connections>
                                     <action selector="endButton:" destination="uCe-Dr-4Kv" eventType="touchUpInside" id="3sG-Co-Boa"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1Wc-Gl-orS">
-                                <rect key="frame" x="326" y="64" width="88" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1Wc-Gl-orS">
+                                <rect key="frame" x="326" y="64" width="74" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 <state key="normal" title="Reset"/>
                                 <connections>
@@ -639,17 +632,34 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6Ax-8P-rSL">
-                                <rect key="frame" x="902" y="64" width="88" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6Ax-8P-rSL">
+                                <rect key="frame" x="20" y="64" width="65" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 <state key="normal" title="Back"/>
                                 <connections>
                                     <segue destination="BYZ-38-t0r" kind="show" id="Vpw-Oe-aOx"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bZv-R1-K4j">
+                                <rect key="frame" x="942" y="64" width="62" height="48"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                <state key="normal" title="Start"/>
+                                <connections>
+                                    <action selector="StartTest:" destination="uCe-Dr-4Kv" eventType="touchUpInside" id="5xX-ga-a5D"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="1Wc-Gl-orS" firstAttribute="firstBaseline" secondItem="6Ax-8P-rSL" secondAttribute="firstBaseline" id="2o7-f4-wm0"/>
+                            <constraint firstItem="yCR-2Z-sau" firstAttribute="firstBaseline" secondItem="6Ax-8P-rSL" secondAttribute="firstBaseline" id="Qm5-ab-t3B"/>
+                            <constraint firstItem="6Ax-8P-rSL" firstAttribute="leading" secondItem="3qg-NQ-QXF" secondAttribute="leadingMargin" id="YTV-Ls-2Ch"/>
+                            <constraint firstItem="yCR-2Z-sau" firstAttribute="leading" secondItem="6Ax-8P-rSL" secondAttribute="trailing" constant="108" id="Zxd-Ot-dHH"/>
+                            <constraint firstItem="bZv-R1-K4j" firstAttribute="firstBaseline" secondItem="6Ax-8P-rSL" secondAttribute="firstBaseline" id="gfi-bb-1K3"/>
+                            <constraint firstItem="6Ax-8P-rSL" firstAttribute="top" secondItem="rq3-r0-MT7" secondAttribute="bottom" constant="44" id="giV-qp-rkv"/>
+                            <constraint firstItem="bZv-R1-K4j" firstAttribute="trailing" secondItem="3qg-NQ-QXF" secondAttribute="trailingMargin" id="nlT-TE-ji5"/>
+                            <constraint firstItem="1Wc-Gl-orS" firstAttribute="leading" secondItem="yCR-2Z-sau" secondAttribute="trailing" constant="82" id="uLP-g9-VCA"/>
+                        </constraints>
                     </view>
                     <connections>
                         <outlet property="StartButton" destination="bZv-R1-K4j" id="wya-f5-EtX"/>
@@ -676,7 +686,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bCa-7d-rcb">
-                                <rect key="frame" x="44" y="66" width="71" height="30"/>
+                                <rect key="frame" x="933" y="66" width="71" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="Rur-gK-AaF"/>
                                 </constraints>
@@ -687,7 +697,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5rw-Jj-8U9">
-                                <rect key="frame" x="667" y="66" width="68" height="30"/>
+                                <rect key="frame" x="642.5" y="66" width="68" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="ljx-E7-Q5D"/>
                                     <constraint firstAttribute="width" constant="68" id="qeB-6r-9cZ"/>
@@ -706,7 +716,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eub-KA-jB3">
-                                <rect key="frame" x="755" y="66" width="150" height="35"/>
+                                <rect key="frame" x="730.5" y="78" width="150" height="35"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="35" id="MqF-BE-cHu"/>
                                     <constraint firstAttribute="width" constant="150" id="O2J-9X-hsw"/>
@@ -715,20 +725,8 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yYV-Ns-n2M">
-                                <rect key="frame" x="915" y="66" width="65" height="30"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="30" id="e2B-O6-FUn"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
-                                <state key="normal" title="Back"/>
-                                <connections>
-                                    <action selector="btnBackTapped:" destination="wNj-51-lN4" eventType="touchUpInside" id="QLN-nm-2Tf"/>
-                                    <segue destination="BYZ-38-t0r" kind="show" id="OeE-YP-4JC"/>
-                                </connections>
-                            </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AcT-sn-nDc">
-                                <rect key="frame" x="586" y="66" width="61" height="30"/>
+                                <rect key="frame" x="561.5" y="66" width="61" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="QHP-8x-S5C"/>
                                 </constraints>
@@ -739,7 +737,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Object Name:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hJe-BY-VQo">
-                                <rect key="frame" x="135" y="66" width="148.5" height="35"/>
+                                <rect key="frame" x="125" y="63.5" width="148.5" height="35"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="35" id="INH-py-iIq"/>
                                 </constraints>
@@ -748,7 +746,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="bezel" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="yyG-aO-hwr">
-                                <rect key="frame" x="291.5" y="66" width="250" height="35"/>
+                                <rect key="frame" x="281.5" y="63.5" width="250" height="35"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="35" id="bfN-tN-ffD"/>
                                     <constraint firstAttribute="width" constant="250" id="oTB-xm-3Hf"/>
@@ -757,23 +755,33 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="25"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yYV-Ns-n2M">
+                                <rect key="frame" x="20" y="66" width="65" height="30"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                <state key="normal" title="Back"/>
+                                <connections>
+                                    <action selector="btnBackTapped:" destination="wNj-51-lN4" eventType="touchUpInside" id="QLN-nm-2Tf"/>
+                                    <segue destination="BYZ-38-t0r" kind="show" id="OeE-YP-4JC"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
+                            <constraint firstItem="hJe-BY-VQo" firstAttribute="centerY" secondItem="yYV-Ns-n2M" secondAttribute="centerY" id="0Gh-6s-0pQ"/>
                             <constraint firstItem="eub-KA-jB3" firstAttribute="leading" secondItem="5rw-Jj-8U9" secondAttribute="trailing" constant="20" id="4JE-7t-UJm"/>
-                            <constraint firstItem="hJe-BY-VQo" firstAttribute="top" secondItem="yYV-Ns-n2M" secondAttribute="top" id="EcX-Rc-a4z"/>
+                            <constraint firstItem="AcT-sn-nDc" firstAttribute="firstBaseline" secondItem="yYV-Ns-n2M" secondAttribute="firstBaseline" id="6xL-7A-SUD"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="bCa-7d-rcb" secondAttribute="trailing" id="Gd7-tm-vCH"/>
                             <constraint firstItem="yyG-aO-hwr" firstAttribute="leading" secondItem="hJe-BY-VQo" secondAttribute="trailing" constant="8" id="Luc-vV-DBa"/>
-                            <constraint firstItem="bCa-7d-rcb" firstAttribute="top" secondItem="yYV-Ns-n2M" secondAttribute="top" id="PPa-Zn-NEv"/>
-                            <constraint firstItem="AcT-sn-nDc" firstAttribute="top" secondItem="yYV-Ns-n2M" secondAttribute="top" id="S72-XA-1Bv"/>
-                            <constraint firstItem="yYV-Ns-n2M" firstAttribute="leading" secondItem="eub-KA-jB3" secondAttribute="trailing" constant="10" id="ULy-Qq-kWt"/>
+                            <constraint firstItem="hJe-BY-VQo" firstAttribute="leading" secondItem="yYV-Ns-n2M" secondAttribute="trailing" constant="40" id="OEW-3Q-cht"/>
+                            <constraint firstItem="yYV-Ns-n2M" firstAttribute="leading" secondItem="eBt-vd-rcb" secondAttribute="leadingMargin" id="PPl-jj-WJn"/>
+                            <constraint firstItem="eub-KA-jB3" firstAttribute="firstBaseline" secondItem="yYV-Ns-n2M" secondAttribute="firstBaseline" id="RwH-VC-Kg2"/>
                             <constraint firstItem="5rw-Jj-8U9" firstAttribute="leading" secondItem="AcT-sn-nDc" secondAttribute="trailing" constant="20" id="VbP-31-8Gg"/>
-                            <constraint firstAttribute="trailing" secondItem="yYV-Ns-n2M" secondAttribute="trailing" constant="44" id="eBJ-Il-eWU"/>
-                            <constraint firstItem="hJe-BY-VQo" firstAttribute="leading" secondItem="bCa-7d-rcb" secondAttribute="trailing" constant="20" id="hzl-2z-fyl"/>
+                            <constraint firstItem="AcT-sn-nDc" firstAttribute="leading" secondItem="yyG-aO-hwr" secondAttribute="trailing" constant="30" id="WP7-5W-FuW"/>
+                            <constraint firstItem="bCa-7d-rcb" firstAttribute="firstBaseline" secondItem="yYV-Ns-n2M" secondAttribute="firstBaseline" id="Xlv-J2-GB2"/>
+                            <constraint firstItem="5rw-Jj-8U9" firstAttribute="firstBaseline" secondItem="yYV-Ns-n2M" secondAttribute="firstBaseline" id="a2j-SQ-GmB"/>
+                            <constraint firstItem="yYV-Ns-n2M" firstAttribute="height" secondItem="bCa-7d-rcb" secondAttribute="height" id="j2m-yZ-Rbo"/>
                             <constraint firstItem="yyG-aO-hwr" firstAttribute="centerY" secondItem="hJe-BY-VQo" secondAttribute="centerY" id="kQy-yE-eZL"/>
-                            <constraint firstItem="eub-KA-jB3" firstAttribute="top" secondItem="yYV-Ns-n2M" secondAttribute="top" id="oD8-z1-jsK"/>
-                            <constraint firstItem="yYV-Ns-n2M" firstAttribute="top" secondItem="xPU-jJ-9wr" secondAttribute="bottom" constant="46" id="oqp-4S-Asr"/>
-                            <constraint firstItem="5rw-Jj-8U9" firstAttribute="top" secondItem="yYV-Ns-n2M" secondAttribute="top" id="rhK-Ju-mBI"/>
-                            <constraint firstItem="bCa-7d-rcb" firstAttribute="leading" secondItem="eBt-vd-rcb" secondAttribute="leading" constant="44" id="zmA-gD-jkg"/>
+                            <constraint firstItem="yYV-Ns-n2M" firstAttribute="top" secondItem="xPU-jJ-9wr" secondAttribute="bottom" constant="46" id="pao-SX-Nin"/>
                         </constraints>
                     </view>
                     <connections>
@@ -4326,7 +4334,6 @@
         <image name="seth1.jpg" width="960" height="960"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="KbP-HI-14n"/>
         <segue reference="Ges-mF-PUS"/>
         <segue reference="Ahl-wP-pho"/>
         <segue reference="fV2-tM-D7d"/>

--- a/iBOCA/Base.lproj/Main.storyboard
+++ b/iBOCA/Base.lproj/Main.storyboard
@@ -2313,44 +2313,50 @@
                         <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zKJ-jD-LKI">
-                                <rect key="frame" x="342" y="66" width="118" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zKJ-jD-LKI">
+                                <rect key="frame" x="342" y="61" width="97" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 <state key="normal" title="Correct"/>
                                 <connections>
                                     <action selector="CorrectAction:" destination="d3Y-Gd-iID" eventType="touchUpInside" id="vcT-Sq-Ite"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7j6-VF-hlm">
-                                <rect key="frame" x="534" y="66" width="134" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7j6-VF-hlm">
+                                <rect key="frame" x="571" y="61" width="114" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 <state key="normal" title="Incorrect"/>
                                 <connections>
                                     <action selector="IncorrectAction:" destination="d3Y-Gd-iID" eventType="touchUpInside" id="B9W-gD-1uH"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7gZ-XH-XKB">
-                                <rect key="frame" x="889" y="64" width="74" height="35"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
-                                <state key="normal" title="Back"/>
-                                <connections>
-                                    <segue destination="BYZ-38-t0r" kind="show" id="lnl-8U-qJ1"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2uo-0f-Zdl">
-                                <rect key="frame" x="76" y="66" width="90" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2uo-0f-Zdl">
+                                <rect key="frame" x="942" y="61" width="62" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 <state key="normal" title="Start"/>
                                 <connections>
                                     <action selector="StartAction:" destination="d3Y-Gd-iID" eventType="touchUpInside" id="Hjv-bt-4Kb"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7gZ-XH-XKB">
+                                <rect key="frame" x="20" y="61" width="65" height="48"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                <state key="normal" title="Back"/>
+                                <connections>
+                                    <segue destination="BYZ-38-t0r" kind="show" id="lnl-8U-qJ1"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="2uo-0f-Zdl" firstAttribute="firstBaseline" secondItem="7gZ-XH-XKB" secondAttribute="firstBaseline" id="8JV-d0-SIJ"/>
+                            <constraint firstItem="zKJ-jD-LKI" firstAttribute="leading" secondItem="7gZ-XH-XKB" secondAttribute="trailing" constant="257" id="RcJ-OO-8cf"/>
+                            <constraint firstItem="zKJ-jD-LKI" firstAttribute="firstBaseline" secondItem="7gZ-XH-XKB" secondAttribute="firstBaseline" id="mRU-ug-5De"/>
+                            <constraint firstItem="7j6-VF-hlm" firstAttribute="firstBaseline" secondItem="7gZ-XH-XKB" secondAttribute="firstBaseline" id="me5-eT-WzC"/>
+                            <constraint firstItem="7gZ-XH-XKB" firstAttribute="leading" secondItem="vLl-Ey-dbX" secondAttribute="leadingMargin" id="n05-eB-1KL"/>
+                            <constraint firstItem="7gZ-XH-XKB" firstAttribute="top" secondItem="pv2-5f-1nn" secondAttribute="bottom" constant="41" id="oF2-3Q-Tx6"/>
+                            <constraint firstItem="2uo-0f-Zdl" firstAttribute="leading" secondItem="7j6-VF-hlm" secondAttribute="trailing" constant="257" id="qUi-Bi-7EF"/>
+                            <constraint firstItem="2uo-0f-Zdl" firstAttribute="trailing" secondItem="vLl-Ey-dbX" secondAttribute="trailingMargin" id="sAf-Bp-c5D"/>
+                        </constraints>
                     </view>
                     <connections>
                         <outlet property="BackButton" destination="7gZ-XH-XKB" id="fr1-AM-q9n"/>
@@ -2382,27 +2388,24 @@
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tt8-rh-alh">
-                                <rect key="frame" x="256" y="72" width="119" height="46"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Tt8-rh-alh">
+                                <rect key="frame" x="293" y="72" width="97" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 <state key="normal" title="Correct"/>
                                 <connections>
                                     <action selector="correctPressed:" destination="XYk-wu-CQY" eventType="touchUpInside" id="U9T-VN-uRT"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iD2-aE-5w8">
-                                <rect key="frame" x="434" y="72" width="154" height="46"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iD2-aE-5w8">
+                                <rect key="frame" x="455" y="72" width="114" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 <state key="normal" title="Incorrect"/>
                                 <connections>
                                     <action selector="incorrectPressed:" destination="XYk-wu-CQY" eventType="touchUpInside" id="d12-sE-xfj"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="89l-7i-vIC">
-                                <rect key="frame" x="634" y="72" width="149" height="46"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="89l-7i-vIC">
+                                <rect key="frame" x="634" y="72" width="92" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 <state key="normal" title="Repeat"/>
                                 <connections>
@@ -2427,26 +2430,36 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fQE-1C-Vrb">
-                                <rect key="frame" x="54" y="72" width="75" height="46"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
-                                <state key="normal" title="Start"/>
-                                <connections>
-                                    <action selector="StartPressed:" destination="XYk-wu-CQY" eventType="touchUpInside" id="wAo-Kf-yVC"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kr3-2p-MY4">
-                                <rect key="frame" x="900" y="72" width="88" height="46"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kr3-2p-MY4">
+                                <rect key="frame" x="20" y="72" width="65" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 <state key="normal" title="Back"/>
                                 <connections>
                                     <segue destination="BYZ-38-t0r" kind="show" id="1MG-jT-bnL"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fQE-1C-Vrb">
+                                <rect key="frame" x="942" y="72" width="62" height="48"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                <state key="normal" title="Start"/>
+                                <connections>
+                                    <action selector="StartPressed:" destination="XYk-wu-CQY" eventType="touchUpInside" id="wAo-Kf-yVC"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="fQE-1C-Vrb" firstAttribute="firstBaseline" secondItem="kr3-2p-MY4" secondAttribute="firstBaseline" id="69R-qX-Vxa"/>
+                            <constraint firstItem="kr3-2p-MY4" firstAttribute="top" secondItem="Isi-2U-1FA" secondAttribute="bottom" constant="52" id="6Rk-Jg-u7A"/>
+                            <constraint firstItem="iD2-aE-5w8" firstAttribute="leading" secondItem="Tt8-rh-alh" secondAttribute="trailing" constant="65" id="Icw-us-wYw"/>
+                            <constraint firstItem="iD2-aE-5w8" firstAttribute="firstBaseline" secondItem="kr3-2p-MY4" secondAttribute="firstBaseline" id="Oki-6Q-tMN"/>
+                            <constraint firstItem="89l-7i-vIC" firstAttribute="firstBaseline" secondItem="kr3-2p-MY4" secondAttribute="firstBaseline" id="YgK-MW-CRo"/>
+                            <constraint firstItem="fQE-1C-Vrb" firstAttribute="trailing" secondItem="PXO-kO-wgA" secondAttribute="trailingMargin" id="Ynz-Gp-zi0"/>
+                            <constraint firstItem="89l-7i-vIC" firstAttribute="leading" secondItem="iD2-aE-5w8" secondAttribute="trailing" constant="65" id="dNT-tD-p7U"/>
+                            <constraint firstItem="iD2-aE-5w8" firstAttribute="centerX" secondItem="PXO-kO-wgA" secondAttribute="centerX" id="hBa-lF-uye"/>
+                            <constraint firstItem="kr3-2p-MY4" firstAttribute="leading" secondItem="PXO-kO-wgA" secondAttribute="leadingMargin" id="qQV-uA-UGh"/>
+                            <constraint firstItem="Tt8-rh-alh" firstAttribute="firstBaseline" secondItem="kr3-2p-MY4" secondAttribute="firstBaseline" id="wED-vV-hfB"/>
+                        </constraints>
                     </view>
                     <connections>
                         <outlet property="BackButton" destination="kr3-2p-MY4" id="E62-X5-mof"/>
@@ -3125,18 +3138,8 @@
                                 <rect key="frame" x="153" y="31" width="175" height="104"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             </pickerView>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="J7A-7c-Gy8">
-                                <rect key="frame" x="910" y="61" width="94" height="46"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
-                                <state key="normal" title="Back"/>
-                                <connections>
-                                    <segue destination="BYZ-38-t0r" kind="show" id="wuj-UQ-84Y"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MK0-oR-YjC">
-                                <rect key="frame" x="20" y="69" width="92" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MK0-oR-YjC">
+                                <rect key="frame" x="942" y="61" width="62" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 <state key="normal" title="Start"/>
                                 <connections>
@@ -3154,8 +3157,22 @@
                                 <rect key="frame" x="513" y="41" width="175" height="85"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             </pickerView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="J7A-7c-Gy8">
+                                <rect key="frame" x="20" y="61" width="65" height="48"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                <state key="normal" title="Back"/>
+                                <connections>
+                                    <segue destination="BYZ-38-t0r" kind="show" id="wuj-UQ-84Y"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="J7A-7c-Gy8" firstAttribute="top" secondItem="m29-n8-Gbe" secondAttribute="bottom" constant="41" id="O65-pu-rQm"/>
+                            <constraint firstItem="MK0-oR-YjC" firstAttribute="trailing" secondItem="9qh-JG-QRx" secondAttribute="trailingMargin" id="T4O-9o-7Op"/>
+                            <constraint firstItem="J7A-7c-Gy8" firstAttribute="leading" secondItem="9qh-JG-QRx" secondAttribute="leadingMargin" id="YUd-xX-GS2"/>
+                            <constraint firstItem="MK0-oR-YjC" firstAttribute="firstBaseline" secondItem="J7A-7c-Gy8" secondAttribute="firstBaseline" id="idd-ie-MGl"/>
+                        </constraints>
                     </view>
                     <connections>
                         <outlet property="numBubblesPicker" destination="7CD-eC-O0b" id="IpG-0k-wjZ"/>
@@ -3689,22 +3706,12 @@
                                     <action selector="EndPressed:" destination="oxe-aZ-ydg" eventType="touchUpInside" id="oqF-8j-loU"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZBp-O1-NC3">
-                                <rect key="frame" x="789" y="55" width="81" height="47"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZBp-O1-NC3">
+                                <rect key="frame" x="20" y="55" width="65" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                 <state key="normal" title="Back"/>
                                 <connections>
                                     <segue destination="BYZ-38-t0r" kind="show" id="HD1-tR-rkD"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b3x-5B-tt3">
-                                <rect key="frame" x="73" y="64" width="83" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
-                                <state key="normal" title="Start"/>
-                                <connections>
-                                    <action selector="StartPressed:" destination="oxe-aZ-ydg" eventType="touchUpInside" id="eZo-JC-ZVV"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bV3-6w-I82">
@@ -3919,11 +3926,21 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b3x-5B-tt3">
+                                <rect key="frame" x="865" y="55" width="62" height="48"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                <state key="normal" title="Start"/>
+                                <connections>
+                                    <action selector="StartPressed:" destination="oxe-aZ-ydg" eventType="touchUpInside" id="eZo-JC-ZVV"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
+                            <constraint firstAttribute="trailingMargin" secondItem="b3x-5B-tt3" secondAttribute="trailing" constant="77" id="0hE-52-K5M"/>
                             <constraint firstItem="Ri7-ld-9Ox" firstAttribute="leading" secondItem="Ehx-RZ-Aa9" secondAttribute="trailing" constant="37" id="0nT-gw-KTL"/>
                             <constraint firstItem="pnW-5O-RbQ" firstAttribute="centerX" secondItem="3LK-eg-yPh" secondAttribute="centerX" id="1xf-zW-jL2"/>
+                            <constraint firstItem="b3x-5B-tt3" firstAttribute="firstBaseline" secondItem="ZBp-O1-NC3" secondAttribute="firstBaseline" id="3E1-oR-0or"/>
                             <constraint firstItem="3LK-eg-yPh" firstAttribute="leading" secondItem="fvR-RS-4Qo" secondAttribute="trailing" constant="37" id="4kI-cV-D6K"/>
                             <constraint firstItem="Ri7-ld-9Ox" firstAttribute="centerX" secondItem="fvR-RS-4Qo" secondAttribute="centerX" id="7dg-eK-H6x"/>
                             <constraint firstItem="Ehx-RZ-Aa9" firstAttribute="top" secondItem="0Ef-UF-5xw" secondAttribute="bottom" constant="37" id="9G3-tL-vdj"/>
@@ -3934,6 +3951,7 @@
                             <constraint firstItem="ka5-GA-veB" firstAttribute="leading" secondItem="SBH-Rd-YmK" secondAttribute="leading" constant="55" id="BFZ-PR-0dh"/>
                             <constraint firstItem="lx4-fR-S98" firstAttribute="centerX" secondItem="Ehx-RZ-Aa9" secondAttribute="centerX" id="BKd-JP-Q59"/>
                             <constraint firstItem="0Ef-UF-5xw" firstAttribute="centerX" secondItem="bV3-6w-I82" secondAttribute="centerX" id="CdR-wO-MXB"/>
+                            <constraint firstItem="ZBp-O1-NC3" firstAttribute="top" secondItem="dKz-K2-T29" secondAttribute="bottom" constant="35" id="JOJ-m2-env"/>
                             <constraint firstItem="Rgp-1o-flC" firstAttribute="centerX" secondItem="SBH-Rd-YmK" secondAttribute="centerX" id="LAQ-6b-Pmm"/>
                             <constraint firstItem="zPk-QR-AMS" firstAttribute="centerX" secondItem="fjj-MU-S8U" secondAttribute="centerX" id="LQV-xc-ZFj"/>
                             <constraint firstItem="Ehx-RZ-Aa9" firstAttribute="centerX" secondItem="bV3-6w-I82" secondAttribute="centerX" id="LUZ-0Z-wJf"/>
@@ -3955,6 +3973,7 @@
                             <constraint firstItem="fvR-RS-4Qo" firstAttribute="centerY" secondItem="bV3-6w-I82" secondAttribute="centerY" id="n81-k2-Q95"/>
                             <constraint firstItem="YU8-sM-77O" firstAttribute="centerX" secondItem="Ri7-ld-9Ox" secondAttribute="centerX" id="oCS-9b-1yS"/>
                             <constraint firstItem="TvU-Pb-ShG" firstAttribute="centerX" secondItem="fvR-RS-4Qo" secondAttribute="centerX" id="oTB-u5-gbM"/>
+                            <constraint firstItem="ZBp-O1-NC3" firstAttribute="leading" secondItem="SBH-Rd-YmK" secondAttribute="leadingMargin" id="pNi-hQ-Jqs"/>
                             <constraint firstItem="lx4-fR-S98" firstAttribute="top" secondItem="Ehx-RZ-Aa9" secondAttribute="bottom" constant="37" id="qiC-cg-tZm"/>
                             <constraint firstItem="YU8-sM-77O" firstAttribute="centerY" secondItem="lx4-fR-S98" secondAttribute="centerY" id="u5M-l2-9eo"/>
                             <constraint firstItem="3LK-eg-yPh" firstAttribute="top" secondItem="bAb-BA-yfp" secondAttribute="bottom" constant="33" id="uQC-DZ-EGD"/>
@@ -4365,6 +4384,6 @@
         <segue reference="Ges-mF-PUS"/>
         <segue reference="eep-iX-tUz"/>
         <segue reference="fV2-tM-D7d"/>
-        <segue reference="e4f-h0-eqr"/>
+        <segue reference="wuj-UQ-84Y"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/iBOCA/Results.swift
+++ b/iBOCA/Results.swift
@@ -36,7 +36,7 @@ class Results: NSObject {
         let duration = Int(elapsedTime)
         var res = name! + " (" + String(duration) + " secs): "
         if numErrors > 0 {
-            res = res + "\(numErrors) Errors "
+            res = res + "\(numErrors) Error\(numErrors > 1 ? "s" : ""); "
         }
         if shortDescription != nil {
             res = res + shortDescription!

--- a/iBOCA/SimpleMemory.swift
+++ b/iBOCA/SimpleMemory.swift
@@ -313,7 +313,9 @@ class SimpleMemoryTask: ViewController, UIPickerViewDelegate {
     }
     
     func startNewTask(){
-        
+        result = Results()
+        result.name = "Simple Memory"
+        result.startTime = Foundation.Date()
         totalTime = 60
         ended = true
         self.isStartNew = true


### PR DESCRIPTION
a.  Please switch the order of "Start" and "Back" buttons on all tests and also on the results page.  "Back" should be on the left when possible.
b.  On the results page for Simple Memory, if you have 1 error, it says “1 Errors Recall” it should say “1 Recall Error”.  "Recall" should come before the word Error and error should not have the “s” in the case of 1.